### PR TITLE
Load sample MIDI by default on iOS startup

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -825,6 +825,32 @@ async function handlePickedFile(file){
     console.error(err);
   }
 }
+
+async function loadMIDIFromNative(base64, fileName = 'sample.mid'){
+  try{
+    const binary = atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for(let i = 0; i < len; i++){ bytes[i] = binary.charCodeAt(i); }
+    const blob = new Blob([bytes], { type: 'audio/midi' });
+    let fileLike;
+    try{
+      fileLike = new File([blob], fileName, { type: blob.type || 'audio/midi', lastModified: Date.now() });
+    }catch{
+      fileLike = {
+        name: fileName,
+        type: blob.type || 'audio/midi',
+        size: blob.size,
+        arrayBuffer: () => blob.arrayBuffer()
+      };
+    }
+    await handlePickedFile(fileLike);
+  }catch(err){
+    console.warn('failed to load MIDI from native:', err);
+  }
+}
+window.__loadMIDIFromNative = loadMIDIFromNative;
+
 function onFileInput(e){
   const f = e.target && e.target.files && e.target.files[0];
   if(f) handlePickedFile(f);
@@ -834,6 +860,9 @@ midiFileInput.addEventListener('input',  onFileInput);
 
 async function loadDefaultMIDI(){
   if(midiData) return;
+  if(window.__NATIVE_APP__){
+    return;
+  }
   try{
     uiLog('loading: sample.mid');
     const res = await fetch('sample.mid');


### PR DESCRIPTION
## Summary
- add a JavaScript helper to accept a MIDI file payload from the native wrapper and skip web fetching when running inside the app
- send the bundled sample.mid file to the web view after it loads so the trainer starts with default content on iOS

## Testing
- not run (iOS simulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f62f39488c8330b97869b5b4bb7151