### PR TITLE
Reduce trainer target circle size

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -482,7 +482,7 @@ function drawTargetNotes(targets, drawRot){
   const {rMax, step}=ringParams(); const cx=cv.width/2, cy=cv.height/2;
   for(const midi of targets){
     const th=angleForMidiDraw(midi, drawRot), r=radiusFromFreq(midiToHz(midi),rMax,step), {x,y}=polarToXY(cx,cy,r,th);
-    ctx.beginPath(); ctx.strokeStyle='rgba(100,255,120,0.95)'; ctx.lineWidth=4; ctx.arc(x,y,20*devicePixelRatio,0,2*Math.PI); ctx.stroke();
+    ctx.beginPath(); ctx.strokeStyle='rgba(100,255,120,0.95)'; ctx.lineWidth=4; ctx.arc(x,y,15*devicePixelRatio,0,2*Math.PI); ctx.stroke();
     ctx.fillStyle='rgba(100,255,120,0.95)'; ctx.font=`${12*devicePixelRatio}px system-ui`; ctx.textAlign='center'; ctx.textBaseline='top';
     ctx.fillText('TARGET', x, y+22*devicePixelRatio);
   }


### PR DESCRIPTION
## Summary
- shrink the green trainer target circle radius to 75% of its previous size for a smaller highlight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fca724304c8330a3c82e429d313be7