### PR TITLE
Add numeric ranking labels for midrange notes

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -482,6 +482,23 @@ function drawNotes(points, drawRot){
   if(low)  ring(low,'rgba(0,200,255,0.95)','LOW','bottom');
   if(high) ring(high,'rgba(255,160,0,0.95)','HIGH','top');
 
+  if(points.length){
+    const strongestByMidi = new Map();
+    for(const p of points){
+      const current = strongestByMidi.get(p.midi);
+      if(!current || p.vel > current.vel){
+        strongestByMidi.set(p.midi, p);
+      }
+    }
+    const ranked = Array.from(strongestByMidi.values())
+      .sort((a,b)=> midiToHz(a.midi) - midiToHz(b.midi));
+    for(let i=0;i<ranked.length;i++){
+      const p = ranked[i];
+      if((low && p.midi === low.midi) || (high && p.midi === high.midi)) continue;
+      ring(p, 'rgba(220,220,220,0.9)', String(i+1), 'top');
+    }
+  }
+
   for(const p of points){
     const theta=angleForMidiDraw(p.midi, drawRot);
     const rAbs=radiusFromFreq(midiToHz(p.midi), rMax, step), {x,y}=polarToXY(cx,cy,rAbs,theta);


### PR DESCRIPTION
## Summary
- keep highlighting of the lowest and highest notes
- add numeric labels to other unique notes to show their relative pitch order

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcec30d1708330ae0dffac4dcd447a