### PR TITLE
Remove rings from numeric note labels

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -479,8 +479,37 @@ function drawNotes(points, drawRot){
       ctx.fillText(label, x, y - labelOffset);
     }
   }
+  function labelOnly(p, label, position = 'top', color = 'rgba(220,220,220,0.9)'){
+    const th=angleForMidiDraw(p.midi, drawRot), r=radiusFromFreq(midiToHz(p.midi),rMax,step), {x,y}=polarToXY(cx,cy,r,th);
+    ctx.fillStyle=color; ctx.font=`${11*devicePixelRatio}px system-ui`; ctx.textAlign='center';
+    const labelOffset = 18 * devicePixelRatio;
+    if(position === 'bottom'){
+      ctx.textBaseline='top';
+      ctx.fillText(label, x, y + labelOffset);
+    }else{
+      ctx.textBaseline='bottom';
+      ctx.fillText(label, x, y - labelOffset);
+    }
+  }
   if(low)  ring(low,'rgba(0,200,255,0.95)','LOW','bottom');
   if(high) ring(high,'rgba(255,160,0,0.95)','HIGH','top');
+
+  if(points.length){
+    const strongestByMidi = new Map();
+    for(const p of points){
+      const current = strongestByMidi.get(p.midi);
+      if(!current || p.vel > current.vel){
+        strongestByMidi.set(p.midi, p);
+      }
+    }
+    const ranked = Array.from(strongestByMidi.values())
+      .sort((a,b)=> midiToHz(a.midi) - midiToHz(b.midi));
+    for(let i=0;i<ranked.length;i++){
+      const p = ranked[i];
+      if((low && p.midi === low.midi) || (high && p.midi === high.midi)) continue;
+      labelOnly(p, String(i+1), 'top');
+    }
+  }
 
   for(const p of points){
     const theta=angleForMidiDraw(p.midi, drawRot);


### PR DESCRIPTION
## Summary
- add a helper to draw numeric pitch ranks without additional circles
- keep LOW/HIGH highlights while rendering plain numeric text for other notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fcec30d1708330ae0dffac4dcd447a