### PR TITLE
Handle out-of-range note rendering around cut ranges

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -399,17 +399,20 @@ function midiToHz(m){ return 440*Math.pow(2,(m-69)/12); }
 function ringParams(){
   const rMax = Math.min(cv.width,cv.height)/2 - MARGIN;
   const octaves = activeOctaveCount();
-  const step = rMax / octaves;
-  return {rMax, step, octaves, minFreq: minDisplayFreq(), maxFreq: maxDisplayFreq()};
+  const minRadius = (highCutOct > 0) ? rMax * 0.1 : 0;
+  const span = Math.max(0, rMax - minRadius);
+  const step = octaves ? (span / octaves) : 0;
+  return {rMax, step, octaves, minRadius, minFreq: minDisplayFreq(), maxFreq: maxDisplayFreq()};
 }
 function baseAngleFromFifthIndex(i){ return ANG0 + 2*Math.PI*(i%12)/12; }
 function angleForMidiAbs(m){ const pc=((m%12)+12)%12; const idx=FIFTH_INDEX[pc]; return baseAngleFromFifthIndex(idx) + diskAngle; } // 物理用
 function angleForMidiDraw(m, drawRot){ const pc=((m%12)+12)%12; const idx=FIFTH_INDEX[pc]; return baseAngleFromFifthIndex(idx) + drawRot; } // 描画用
-function radiusFromFreq(f, rMax, step){
+function radiusFromFreq(f, rMax, step, minRadius = 0){
   const octaves = activeOctaveCount();
   const oc = Math.log2(f / minDisplayFreq());
   const ocClamped = Math.max(0, Math.min(octaves, oc));
-  return rMax - step*ocClamped;
+  const r = rMax - step*ocClamped;
+  return Math.max(minRadius, Math.min(rMax, r));
 }
 function polarToXY(cx,cy,r,th){ return { x: cx + r*Math.cos(th), y: cy - r*Math.sin(th) }; }
 function shortestDelta(a,b){ let d=b-a; while(d> Math.PI) d-=2*Math.PI; while(d<=-Math.PI) d+=2*Math.PI; return d; }
@@ -544,24 +547,31 @@ const fileNotes = new Map();     // 再生中のMIDIファイル由来
 /* ===== Drawing ===== */
 function drawNotes(points, drawRot){
   if(!points.length) return;
-  const {rMax, step, minFreq: displayMinFreq, maxFreq: displayMaxFreq}=ringParams(); const cx=cv.width/2, cy=cv.height/2;
+  const {rMax, step, minRadius, minFreq: displayMinFreq, maxFreq: displayMaxFreq}=ringParams(); const cx=cv.width/2, cy=cv.height/2;
 
-  const filtered = [];
+  const inRange = [];
+  const belowRange = [];
+  const aboveRange = [];
   for(const p of points){
     const f = midiToHz(p.midi);
-    if(f < displayMinFreq || f > displayMaxFreq) continue;
-    filtered.push({midi:p.midi, vel:p.vel, f});
+    if(f < displayMinFreq){
+      belowRange.push({midi:p.midi, vel:p.vel, f});
+    }else if(f > displayMaxFreq){
+      aboveRange.push({midi:p.midi, vel:p.vel, f});
+    }else{
+      inRange.push({midi:p.midi, vel:p.vel, f});
+    }
   }
-  if(!filtered.length) return;
+  if(!inRange.length && !belowRange.length && !aboveRange.length) return;
 
   let low=null, high=null;
-  for(const p of filtered){
+  for(const p of inRange){
     if(!low || p.f<low.f) low=p;
     if(!high|| p.f>high.f) high=p;
   }
   function ring(p, color, label, position = 'top'){
     const freq = (p && p.f!=null) ? p.f : midiToHz(p.midi);
-    const th=angleForMidiDraw(p.midi, drawRot), r=radiusFromFreq(freq,rMax,step), {x,y}=polarToXY(cx,cy,r,th);
+    const th=angleForMidiDraw(p.midi, drawRot), r=radiusFromFreq(freq,rMax,step,minRadius), {x,y}=polarToXY(cx,cy,r,th);
     ctx.beginPath(); ctx.strokeStyle=color; ctx.lineWidth=3; ctx.arc(x,y,16+10*p.vel*devicePixelRatio,0,2*Math.PI); ctx.stroke();
     ctx.fillStyle=color; ctx.font=`${11*devicePixelRatio}px system-ui`; ctx.textAlign='center';
     const labelOffset = 22 * devicePixelRatio;
@@ -575,7 +585,7 @@ function drawNotes(points, drawRot){
   }
   function labelOnly(p, label, position = 'top', color = 'rgba(220,220,220,0.9)'){
     const freq = (p && p.f!=null) ? p.f : midiToHz(p.midi);
-    const th=angleForMidiDraw(p.midi, drawRot), r=radiusFromFreq(freq,rMax,step), {x,y}=polarToXY(cx,cy,r,th);
+    const th=angleForMidiDraw(p.midi, drawRot), r=radiusFromFreq(freq,rMax,step,minRadius), {x,y}=polarToXY(cx,cy,r,th);
     ctx.fillStyle=color; ctx.font=`${11*devicePixelRatio}px system-ui`; ctx.textAlign='center';
     const labelOffset = 18 * devicePixelRatio;
     if(position === 'bottom'){
@@ -589,9 +599,9 @@ function drawNotes(points, drawRot){
   if(low)  ring(low,'rgba(0,200,255,0.95)','LOW','bottom');
   if(high) ring(high,'rgba(255,160,0,0.95)','HIGH','top');
 
-  if(filtered.length){
+  if(inRange.length){
     const strongestByMidi = new Map();
-    for(const p of filtered){
+    for(const p of inRange){
       const current = strongestByMidi.get(p.midi);
       if(!current || p.vel > current.vel){
         strongestByMidi.set(p.midi, p);
@@ -606,24 +616,42 @@ function drawNotes(points, drawRot){
     }
   }
 
-  for(const p of filtered){
+  for(const p of inRange){
     const theta=angleForMidiDraw(p.midi, drawRot);
-    const rAbs=radiusFromFreq(p.f, rMax, step), {x,y}=polarToXY(cx,cy,rAbs,theta);
+    const rAbs=radiusFromFreq(p.f, rMax, step, minRadius), {x,y}=polarToXY(cx,cy,rAbs,theta);
     const radius=4+12*p.vel, alpha=0.3+0.6*p.vel;
     ctx.beginPath(); ctx.fillStyle=`rgba(255,255,255,${alpha})`; ctx.arc(x,y,radius,0,2*Math.PI); ctx.fill();
   }
 
-  if(filtered.length>=2){
-    const xs = filtered.map(p=>({m:p.midi,f:p.f})).sort((a,b)=>a.f-b.f);
+  if(inRange.length>=2){
+    const xs = inRange.map(p=>({m:p.midi,f:p.f})).sort((a,b)=>a.f-b.f);
     ctx.lineWidth=2; ctx.strokeStyle=`rgba(255,255,255,${linkAlpha})`;
     for(let i=0;i<xs.length-1;i++){
       const m0=xs[i].m,f0=xs[i].f,m1=xs[i+1].m,f1=xs[i+1].f;
-      const r0=radiusFromFreq(f0,rMax,step), th0=angleForMidiDraw(m0, drawRot);
-      const r1=radiusFromFreq(f1,rMax,step), th1=angleForMidiDraw(m1, drawRot);
+      const r0=radiusFromFreq(f0,rMax,step,minRadius), th0=angleForMidiDraw(m0, drawRot);
+      const r1=radiusFromFreq(f1,rMax,step,minRadius), th1=angleForMidiDraw(m1, drawRot);
       const dth = shortestDelta(th0, th1);
       const steps=48; ctx.beginPath();
       for(let s=0;s<=steps;s++){ const t=s/steps, r=r0+t*(r1-r0), th=th0+t*dth; const {x,y}=polarToXY(cx,cy,r,th); if(s===0) ctx.moveTo(x,y); else ctx.lineTo(x,y); }
       ctx.stroke();
+    }
+  }
+
+  if(belowRange.length || aboveRange.length){
+    const highMarkerRadius = Math.max(minRadius, rMax * 0.1);
+    const drawOutOfRange = (list, radius, color)=>{
+      for(const p of list){
+        const theta = angleForMidiDraw(p.midi, drawRot);
+        const {x,y}=polarToXY(cx,cy,radius,theta);
+        const markerRadius=4+12*p.vel;
+        ctx.beginPath(); ctx.fillStyle=color; ctx.arc(x,y,markerRadius,0,2*Math.PI); ctx.fill();
+      }
+    };
+    if(belowRange.length){
+      drawOutOfRange(belowRange, rMax, 'rgba(255,120,120,0.85)');
+    }
+    if(aboveRange.length){
+      drawOutOfRange(aboveRange, highMarkerRadius, 'rgba(120,180,255,0.85)');
     }
   }
 }
@@ -631,11 +659,11 @@ function drawNotes(points, drawRot){
 /* ターゲット描画（トレーナー） */
 function drawTargetNotes(targets, drawRot){
   if(!targets || !targets.length) return;
-  const {rMax, step, minFreq: displayMinFreq, maxFreq: displayMaxFreq}=ringParams(); const cx=cv.width/2, cy=cv.height/2;
+  const {rMax, step, minRadius, minFreq: displayMinFreq, maxFreq: displayMaxFreq}=ringParams(); const cx=cv.width/2, cy=cv.height/2;
   for(const midi of targets){
     const freq = midiToHz(midi);
     if(freq < displayMinFreq || freq > displayMaxFreq) continue;
-    const th=angleForMidiDraw(midi, drawRot), r=radiusFromFreq(freq,rMax,step), {x,y}=polarToXY(cx,cy,r,th);
+    const th=angleForMidiDraw(midi, drawRot), r=radiusFromFreq(freq,rMax,step,minRadius), {x,y}=polarToXY(cx,cy,r,th);
     ctx.beginPath(); ctx.strokeStyle='rgba(100,255,120,0.95)'; ctx.lineWidth=4; ctx.arc(x,y,15*devicePixelRatio,0,2*Math.PI); ctx.stroke();
     ctx.fillStyle='rgba(100,255,120,0.95)'; ctx.font=`${12*devicePixelRatio}px system-ui`; ctx.textAlign='center'; ctx.textBaseline='top';
     ctx.fillText('TARGET', x, y+22*devicePixelRatio);
@@ -665,7 +693,7 @@ function drawMovableDoNumbers(halfCenter, rMax, cx, cy){
 let prevT=null;
 function draw(){
   const w=cv.width, h=cv.height, cx=w/2, cy=h/2;
-  const {rMax, step, octaves, minFreq: displayMinFreq, maxFreq: displayMaxFreq} = ringParams();
+  const {rMax, step, octaves, minRadius, minFreq: displayMinFreq, maxFreq: displayMaxFreq} = ringParams();
   const now = performance.now()/1000;
   const dt = prevT? Math.max(1/240, Math.min(0.25, now-prevT)) : 1/60;
   prevT = now;
@@ -683,7 +711,7 @@ function draw(){
   const hasPhysInput = physicsPoints.length>0;
 
   // 物理
-  const tau = hasPhysInput ? torqueFromPoints(physicsPoints, GRAV_ABS, rMax, step, displayMinFreq, displayMaxFreq, excludeMode) : 0;
+  const tau = hasPhysInput ? torqueFromPoints(physicsPoints, GRAV_ABS, rMax, step, minRadius, displayMinFreq, displayMaxFreq, excludeMode) : 0;
   const alpha = tau / Math.max(1e-6, diskMass);
   if (snapZeroAlpha && Math.abs(alpha) < 1e-6){
     diskOmega = 0;
@@ -930,13 +958,13 @@ document.addEventListener('DOMContentLoaded', ()=>{
 });
 
 /* ===== Disk torque ===== */
-function torqueFromPoints(points, gravAbs, rMax, step, minFreq, maxFreq, excludeMode){
+function torqueFromPoints(points, gravAbs, rMax, step, minRadius, minFreq, maxFreq, excludeMode){
   let tau = 0;
   for(const p of points){
     const thAbs = angleForMidiAbs(p.midi);  // ディスク絶対角
     const freq = midiToHz(p.midi);
     if(freq < minFreq || freq > maxFreq) continue;
-    const r = radiusFromFreq(freq, rMax, step);
+    const r = radiusFromFreq(freq, rMax, step, minRadius);
     const rn = r / rMax;
     const d = shortestDelta(gravAbs, thAbs);
     const absd = Math.abs(d);


### PR DESCRIPTION
## Summary
- prevent the high-cut display from mapping notes into the innermost tenth of the disk
- visualize notes outside the active range at the rim or inner marker with colored indicators
- ensure radius calculations in drawing and torque code share the adjusted minimum radius

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fdbf1d41908330803cab6519f05ac9