### PR TITLE
Include out-of-range notes when determining HIGH/LOW

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -565,7 +565,8 @@ function drawNotes(points, drawRot){
   if(!inRange.length && !belowRange.length && !aboveRange.length) return;
 
   let low=null, high=null;
-  for(const p of inRange){
+  const allPoints = [...inRange, ...belowRange, ...aboveRange];
+  for(const p of allPoints){
     if(!low || p.f<low.f) low=p;
     if(!high|| p.f>high.f) high=p;
   }


### PR DESCRIPTION
## Summary
- include notes outside the display range when determining the LOW and HIGH markers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fdd6b960e08330829106f074886355