### PR TITLE
Harden WKWebView content access controls

### DIFF
--- a/Tonality Visualizer/WebView.swift
+++ b/Tonality Visualizer/WebView.swift
@@ -2,7 +2,10 @@ import SwiftUI
 import WebKit
 
 struct WebView: UIViewRepresentable {
-    func makeCoordinator() -> Coordinator { Coordinator() }
+    func makeCoordinator() -> Coordinator {
+        let basePath = Bundle.main.resourceURL?.standardizedFileURL.path ?? ""
+        return Coordinator(allowedBasePath: basePath)
+    }
 
     func makeUIView(context: Context) -> WKWebView {
         let uc = WKUserContentController()


### PR DESCRIPTION
## Summary
- create the web view coordinator with the bundle path so navigation decisions can be scoped to app resources
- block navigation away from bundled file URLs and deny media capture requests from untrusted origins

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68fde3be7c9c8330bff1721bc26b883a