### PR TITLE
Fix concentric ring rendering when reducing low cut on iPhone

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -766,7 +766,14 @@ function draw(){
   // 同心円
   ctx.strokeStyle='rgba(255,255,255,0.22)';
   ctx.lineWidth = 1.5;
-  for(let i=0;i<=octaves;i++){ const r=rMax - i*step; ctx.beginPath(); ctx.arc(cx,cy,r,0,2*Math.PI); ctx.stroke(); }
+  for(let i=0;i<=octaves;i++){
+    const rRaw = rMax - i*step;
+    const radius = Math.max(minRadius, Math.min(rMax, rRaw));
+    if(radius <= 0) continue; // iOS Safari throws if radius is 0 or negative
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, 2*Math.PI);
+    ctx.stroke();
+  }
   ctx.lineWidth = 1;
 
   if(440 >= displayMinFreq && 440 <= displayMaxFreq){


### PR DESCRIPTION
## Summary
- clamp the concentric ring radius before drawing it so Safari never receives zero/negative radii
- skip the innermost circle when the computed radius would underflow, avoiding the rendering abort on iPhone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff7a6cc3c48330aa79bb8fb6d21abf