### PR TITLE
Move white-key gradient split to black-key midpoint

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1857,7 +1857,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
       }
       return;
     }
-    const boundaryY = key.y + blackHeight;
+    const boundaryY = key.y + blackHeight / 2;
     if(movable){
       ctx.fillStyle = movable;
       ctx.fillRect(key.x, key.y, key.width, Math.max(0, boundaryY - key.y));


### PR DESCRIPTION
### Motivation
- Adjust the white-key color-band split so the gradient boundary sits at the midpoint of the black key height instead of at the black key bottom, to place the split between the black key's upper and lower halves.

### Description
- Update `boundaryY` in `drawKeyBand` for white keys in `Tonality Visualizer/index.html` from `key.y + blackHeight` to `key.y + blackHeight / 2`.

### Testing
- Started a local HTTP server and captured a screenshot via Playwright of `Tonality Visualizer/index.html` to visually verify the keyboard rendering, and committed the change; the verification and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aeff04a588330adde76f537573d88)