### PR TITLE
最高音に対応する鍵盤キーをハイライト

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1742,7 +1742,7 @@ function movableDoStepForMidi(midi, drawRot, halfCenter){
   return step;
 }
 
-function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCenter){
+function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCenter, highestMidi=null){
   if(!keyboardEnabled) return;
   const {minMidi, maxMidi} = midiRangeFromDisplay(displayMinFreq, displayMaxFreq);
   if(minMidi > maxMidi) return;
@@ -2056,6 +2056,24 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     }else{
       drawKeyLabels(key, labels, 'rgba(10,10,10,0.9)');
     }
+  }
+
+  const highlightedKey = (highestMidi != null)
+    ? keys.find((key)=> key.midi === highestMidi)
+    : null;
+  if(highlightedKey){
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,160,0,0.98)';
+    ctx.lineWidth = Math.max(2, 3 * devicePixelRatio);
+    ctx.shadowColor = 'rgba(255,200,0,0.85)';
+    ctx.shadowBlur = 12 * devicePixelRatio;
+    ctx.strokeRect(
+      highlightedKey.x - ctx.lineWidth / 2,
+      highlightedKey.y - ctx.lineWidth / 2,
+      highlightedKey.width + ctx.lineWidth,
+      highlightedKey.height + ctx.lineWidth
+    );
+    ctx.restore();
   }
   ctx.restore();
 }
@@ -2383,8 +2401,10 @@ function draw(){
   const filePts = mapToPoints(fileNotes);
   const activeNotes = mergeNoteMaps(liveNotes, tapNotes, lockedTouchNotes, fileNotes);
   let baseMidi = null;
+  let highestMidi = null;
   for(const midi of activeNotes.keys()){
     if(baseMidi == null || midi < baseMidi) baseMidi = midi;
+    if(highestMidi == null || midi > highestMidi) highestMidi = midi;
   }
   if(baseMidi != null) lastKeyboardBaseMidi = baseMidi;
 
@@ -2397,7 +2417,14 @@ function draw(){
     if(tn && tn.length) drawTargetNotes(tn, drawRot, trainer.hitNotes);
   }
 
-  drawKeyboard(displayMinFreq, displayMaxFreq, (baseMidi != null ? baseMidi : lastKeyboardBaseMidi), drawRot, halfCenter);
+  drawKeyboard(
+    displayMinFreq,
+    displayMaxFreq,
+    (baseMidi != null ? baseMidi : lastKeyboardBaseMidi),
+    drawRot,
+    halfCenter,
+    highestMidi
+  );
 
   requestAnimationFrame(draw);
 }

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1742,7 +1742,7 @@ function movableDoStepForMidi(midi, drawRot, halfCenter){
   return step;
 }
 
-function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCenter, highestMidi=null){
+function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCenter, lowestMidi=null, highestMidi=null){
   if(!keyboardEnabled) return;
   const {minMidi, maxMidi} = midiRangeFromDisplay(displayMinFreq, displayMaxFreq);
   if(minMidi > maxMidi) return;
@@ -2048,6 +2048,44 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   }
   drawBlackKeyOverlay();
 
+  const highlightKeysForMidi = (targetMidi)=>{
+    if(targetMidi == null) return [];
+    if(targetMidi >= startMidi && targetMidi <= endMidi){
+      return keys.filter((key)=> key.midi === targetMidi);
+    }
+    const targetPc = ((targetMidi % 12) + 12) % 12;
+    return keys.filter((key)=> key.pc === targetPc);
+  };
+
+  const drawHighlight = (targetKeys, strokeStyle, shadowColor)=>{
+    if(!targetKeys.length) return;
+    ctx.save();
+    ctx.strokeStyle = strokeStyle;
+    ctx.lineWidth = Math.max(2, 3 * devicePixelRatio);
+    ctx.shadowColor = shadowColor;
+    ctx.shadowBlur = 12 * devicePixelRatio;
+    for(const key of targetKeys){
+      ctx.strokeRect(
+        key.x - ctx.lineWidth / 2,
+        key.y - ctx.lineWidth / 2,
+        key.width + ctx.lineWidth,
+        key.height + ctx.lineWidth
+      );
+    }
+    ctx.restore();
+  };
+
+  drawHighlight(
+    highlightKeysForMidi(lowestMidi),
+    'rgba(0,200,255,0.98)',
+    'rgba(100,220,255,0.85)'
+  );
+  drawHighlight(
+    highlightKeysForMidi(highestMidi),
+    'rgba(255,160,0,0.98)',
+    'rgba(255,200,0,0.85)'
+  );
+
   for(const key of keys){
     const labels = buildLabels(key.midi);
     if(!labels.length) continue;
@@ -2056,24 +2094,6 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     }else{
       drawKeyLabels(key, labels, 'rgba(10,10,10,0.9)');
     }
-  }
-
-  const highlightedKey = (highestMidi != null)
-    ? keys.find((key)=> key.midi === highestMidi)
-    : null;
-  if(highlightedKey){
-    ctx.save();
-    ctx.strokeStyle = 'rgba(255,160,0,0.98)';
-    ctx.lineWidth = Math.max(2, 3 * devicePixelRatio);
-    ctx.shadowColor = 'rgba(255,200,0,0.85)';
-    ctx.shadowBlur = 12 * devicePixelRatio;
-    ctx.strokeRect(
-      highlightedKey.x - ctx.lineWidth / 2,
-      highlightedKey.y - ctx.lineWidth / 2,
-      highlightedKey.width + ctx.lineWidth,
-      highlightedKey.height + ctx.lineWidth
-    );
-    ctx.restore();
   }
   ctx.restore();
 }
@@ -2401,9 +2421,11 @@ function draw(){
   const filePts = mapToPoints(fileNotes);
   const activeNotes = mergeNoteMaps(liveNotes, tapNotes, lockedTouchNotes, fileNotes);
   let baseMidi = null;
+  let lowestMidi = null;
   let highestMidi = null;
   for(const midi of activeNotes.keys()){
     if(baseMidi == null || midi < baseMidi) baseMidi = midi;
+    if(lowestMidi == null || midi < lowestMidi) lowestMidi = midi;
     if(highestMidi == null || midi > highestMidi) highestMidi = midi;
   }
   if(baseMidi != null) lastKeyboardBaseMidi = baseMidi;
@@ -2423,6 +2445,7 @@ function draw(){
     (baseMidi != null ? baseMidi : lastKeyboardBaseMidi),
     drawRot,
     halfCenter,
+    lowestMidi,
     highestMidi
   );
 

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1876,23 +1876,23 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     if(!movable && !distance) return;
     if(key.isBlack){
       const boundaryY = key.y + key.height / 2;
-      if(movable){
-        ctx.fillStyle = movable;
-        ctx.fillRect(key.x, key.y, key.width, boundaryY - key.y);
-      }
       if(distance){
         ctx.fillStyle = distance;
+        ctx.fillRect(key.x, key.y, key.width, boundaryY - key.y);
+      }
+      if(movable){
+        ctx.fillStyle = movable;
         ctx.fillRect(key.x, boundaryY, key.width, key.y + key.height - boundaryY);
       }
       return;
     }
     const boundaryY = key.y + blackHeight / 2;
-    if(movable){
-      ctx.fillStyle = movable;
-      ctx.fillRect(key.x, key.y, key.width, Math.max(0, boundaryY - key.y));
-    }
     if(distance){
       ctx.fillStyle = distance;
+      ctx.fillRect(key.x, key.y, key.width, Math.max(0, boundaryY - key.y));
+    }
+    if(movable){
+      ctx.fillStyle = movable;
       ctx.fillRect(key.x, boundaryY, key.width, Math.max(0, key.y + key.height - boundaryY));
     }
   };
@@ -1986,8 +1986,8 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     const lineHeightDisk = Math.max(blackWidth + 6 * devicePixelRatio, lineHeightText);
     const strokeColor = key.isBlack ? 'rgba(0,0,0,0.7)' : 'rgba(255,255,255,0.8)';
     let yCursor = key.y + key.height - 8 * devicePixelRatio;
-    const movableTopY = key.y + 6 * devicePixelRatio;
-    const distanceY = key.y + blackHeight - textSize - 2 * devicePixelRatio;
+    const distanceTopY = key.y + 6 * devicePixelRatio;
+    const movableBottomY = key.y + blackHeight - textSize - 2 * devicePixelRatio;
     const miniDiskY = key.y + blackHeight / 2;
     for(let i=labels.length-1; i>=0; i--){
       const label = labels[i];
@@ -2003,8 +2003,8 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
         drawMiniDisk(diskX, miniDiskY, label);
       }else if(label.text){
         const textY = (label.kind === 'movable')
-          ? movableTopY
-          : ((label.kind === 'distance') ? distanceY : yCursor);
+          ? movableBottomY
+          : ((label.kind === 'distance') ? distanceTopY : yCursor);
         ctx.font = `${textSize}px system-ui`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';


### PR DESCRIPTION
### Motivation
- ライブ／ファイル入力中に最高音がどの鍵盤位置に対応するかを視覚的に分かりやすくするために、鍵盤表示で最高音キーをハイライトする処理を追加しました。

### Description
- `drawKeyboard` に引数 `highestMidi` を追加して最高音を受け取れるようにしました。  
- 描画ループ（`draw`）で `mergeNoteMaps(liveNotes, tapNotes, lockedTouchNotes, fileNotes)` から `highestMidi` を算出して `drawKeyboard(...)` に渡すようにしました。  
- 鍵盤上で該当する `key.midi === highestMidi` を見つけた場合にオレンジの外枠とグローを `ctx.strokeRect`／`ctx.shadowBlur` 等で描画するハイライト処理を追加しました。  
- 変更ファイルは `Tonality Visualizer/index.html` のみです。

### Testing
- `git diff --check` を実行して差分の静的チェックを行い問題はありませんでした（成功）。  
- 開発サーバーを `python3 -m http.server 4173` で起動してページが読み込めることを確認しました（成功）。  
- Playwright を使って `http://127.0.0.1:4173/Tonality%20Visualizer/index.html` を開き、スクリーンショット `artifacts/keyboard-highest-note-highlight.png` を取得してハイライト表示を目視確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a41767142483308e555233bb6fa430)