### PR TITLE
Reduce white-key lower area and allow keyboard up to 2x disk width

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1766,13 +1766,15 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   const {cx} = canvasCenter();
   const {rMax} = ringParams();
   const diskDiameter = (rMax + 8) * 2;
-  const width = Math.min(cv.width - padding * 2, diskDiameter);
+  const width = Math.min(cv.width - padding * 2, diskDiameter * 2);
   const x = cx - width / 2;
   if(width <= 0 || keyboardHeight <= 0) return;
 
   const whiteWidth = width / whiteKeys.length;
   const blackWidth = whiteWidth * 0.54;
   const blackHeight = keyboardHeight * 0.6;
+  const whiteLowerHeight = Math.max(0, (keyboardHeight - blackHeight) * 0.5);
+  const whiteHeight = blackHeight + whiteLowerHeight;
 
   const BLACK_CENTER_OFFSET_RATIO = {
     1: -0.12766, // C#
@@ -1788,7 +1790,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
       key.x = x + whiteIndex * whiteWidth;
       key.y = y;
       key.width = whiteWidth;
-      key.height = keyboardHeight;
+      key.height = whiteHeight;
       key.whiteIndex = whiteIndex;
       whiteIndex++;
     }else{

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -640,6 +640,15 @@ document.getElementById('lang').addEventListener('change', e=>{
   applyI18N(); saveSettings();
 });
 
+function collectKeyboardSettings(){
+  return {
+    enabled: keyboardToggle.checked,
+    movableDo: keyboardMovableToggle.checked,
+    distance: keyboardDistanceToggle.checked,
+    fifthAngle: keyboardFifthToggle.checked
+  };
+}
+
 // UIの状態をオブジェクトにまとめて保存用に返す
 function collectSettingsFromUI(){
   // 保存対象のプロパティを列挙
@@ -654,6 +663,7 @@ function collectSettingsFromUI(){
     noteDotSize: noteDotSizeSlider.value,
     labelSize: labelSizeSlider.value, labelBG: labelBGSlider.value,
     labelAlpha: labelAlphaSlider.value,
+    keyboard: collectKeyboardSettings(),
     keyboardEnabled: keyboardToggle.checked,
     keyboardMovableDo: keyboardMovableToggle.checked,
     keyboardDistance: keyboardDistanceToggle.checked,
@@ -756,6 +766,13 @@ function applySettings(settings, {force = false} = {}){
   if(has('labelAlpha')){
     labelAlphaSlider.value = s.labelAlpha;
     labelAlphaSlider.oninput();
+  }
+  const keyboardPreset = (s.keyboard && typeof s.keyboard === 'object') ? s.keyboard : null;
+  if(keyboardPreset){
+    if('enabled' in keyboardPreset) keyboardToggle.checked = !!keyboardPreset.enabled;
+    if('movableDo' in keyboardPreset) keyboardMovableToggle.checked = !!keyboardPreset.movableDo;
+    if('distance' in keyboardPreset) keyboardDistanceToggle.checked = !!keyboardPreset.distance;
+    if('fifthAngle' in keyboardPreset) keyboardFifthToggle.checked = !!keyboardPreset.fifthAngle;
   }
   if(has('keyboardEnabled')){
     keyboardToggle.checked = !!s.keyboardEnabled;
@@ -2075,13 +2092,22 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   }
   drawBlackKeyOverlay();
 
-  const highlightKeysForMidi = (targetMidi)=>{
+  const highlightKeysForMidi = (targetMidi, role)=>{
     if(targetMidi == null) return [];
+    let candidates;
     if(targetMidi >= startMidi && targetMidi <= endMidi){
-      return keys.filter((key)=> key.midi === targetMidi);
+      candidates = keys.filter((key)=> key.midi === targetMidi);
+    }else{
+      const targetPc = ((targetMidi % 12) + 12) % 12;
+      candidates = keys.filter((key)=> key.pc === targetPc);
     }
-    const targetPc = ((targetMidi % 12) + 12) % 12;
-    return keys.filter((key)=> key.pc === targetPc);
+    if(role === 'lowest' && highestMidi != null){
+      candidates = candidates.filter((key)=> key.midi <= highestMidi);
+    }
+    if(role === 'highest' && lowestMidi != null){
+      candidates = candidates.filter((key)=> key.midi >= lowestMidi);
+    }
+    return candidates;
   };
 
   const drawHighlight = (targetKeys, strokeStyle, shadowColor)=>{
@@ -2103,12 +2129,12 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   };
 
   drawHighlight(
-    highlightKeysForMidi(lowestMidi),
+    highlightKeysForMidi(lowestMidi, 'lowest'),
     'rgba(0,200,255,0.98)',
     'rgba(100,220,255,0.85)'
   );
   drawHighlight(
-    highlightKeysForMidi(highestMidi),
+    highlightKeysForMidi(highestMidi, 'highest'),
     'rgba(255,160,0,0.98)',
     'rgba(255,200,0,0.85)'
   );

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1773,8 +1773,6 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   const whiteWidth = width / whiteKeys.length;
   const blackWidth = whiteWidth * 0.54;
   const blackHeight = keyboardHeight * 0.6;
-  const whiteLowerHeight = Math.max(0, (keyboardHeight - blackHeight) * 0.5);
-  const whiteHeight = blackHeight + whiteLowerHeight;
 
   const BLACK_CENTER_OFFSET_RATIO = {
     1: -0.12766, // C#
@@ -1790,7 +1788,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
       key.x = x + whiteIndex * whiteWidth;
       key.y = y;
       key.width = whiteWidth;
-      key.height = whiteHeight;
+      key.height = keyboardHeight;
       key.whiteIndex = whiteIndex;
       whiteIndex++;
     }else{

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -930,42 +930,51 @@ fileOp.addEventListener('change', ()=>{ updateFileOpUI(); saveSettings(); });
 function midiToHz(m){ return 440*Math.pow(2,(m-69)/12); }
 function hzToMidi(f){ return 12*Math.log2(f/440)+69; }
 function keyboardMetrics(){
-  if(!keyboardEnabled) return {active:false, height:0, padding:0, reserved:0};
+  if(!keyboardEnabled) return {active:false, mode:'none', height:0, padding:0, reservedBottom:0, reservedRight:0, panelWidth:0, panelGap:0};
   const padding = 16 * devicePixelRatio;
-  const halfWidth = cv.width / 2;
-  const radiusByWidth = Math.max(1, halfWidth - MARGIN);
-  const minDiskRadius = radiusByWidth * 0.85;
-  const maxHeightForDisk = cv.height - (minDiskRadius + MARGIN) * 2 - padding * 2;
-  const minHeight = 72 * devicePixelRatio;
-  const preferredHeight = Math.min(180 * devicePixelRatio, cv.height * 0.28);
-  const clampedMax = Math.max(0, maxHeightForDisk);
-  const height = Math.max(0, Math.min(clampedMax, Math.max(minHeight, preferredHeight)));
-  return {active:true, height, padding, reserved: height + padding * 2};
+  const height = Math.min(140 * devicePixelRatio, cv.height * 0.25);
+  const landscape = cv.width > cv.height * 1.25;
+  if(landscape){
+    const panelGap = 24 * devicePixelRatio;
+    const desiredPanelWidth = cv.width * 0.36;
+    const minDiskAreaWidth = cv.height * 0.9;
+    const maxPanelWidth = Math.max(0, cv.width - minDiskAreaWidth - panelGap);
+    const panelWidth = Math.min(desiredPanelWidth, maxPanelWidth);
+    if(panelWidth >= 180 * devicePixelRatio){
+      return {active:true, mode:'side', height, padding, reservedBottom:0, reservedRight:panelWidth + panelGap, panelWidth, panelGap};
+    }
+  }
+  return {active:true, mode:'bottom', height, padding, reservedBottom:height + padding * 2, reservedRight:0, panelWidth:0, panelGap:0};
 }
 function canvasCenter(){
   const keyboard = keyboardMetrics();
-  const availableHeight = Math.max(1, cv.height - keyboard.reserved);
+  const availableWidth = Math.max(1, cv.width - keyboard.reservedRight);
+  const availableHeight = Math.max(1, cv.height - keyboard.reservedBottom);
   return {
-    cx: cv.width / 2,
+    cx: availableWidth / 2,
     cy: availableHeight / 2,
-    reserved: keyboard.reserved
+    reserved: keyboard.reservedBottom,
+    reservedRight: keyboard.reservedRight
   };
 }
 function canvasCenterCss(){
   const rect = cv.getBoundingClientRect();
   const keyboard = keyboardMetrics();
-  const reservedCss = keyboard.reserved / devicePixelRatio;
-  const availableHeightCss = Math.max(1, rect.height - reservedCss);
+  const reservedBottomCss = keyboard.reservedBottom / devicePixelRatio;
+  const reservedRightCss = keyboard.reservedRight / devicePixelRatio;
+  const availableWidthCss = Math.max(1, rect.width - reservedRightCss);
+  const availableHeightCss = Math.max(1, rect.height - reservedBottomCss);
   return {
-    cx: rect.left + rect.width / 2,
+    cx: rect.left + availableWidthCss / 2,
     cy: rect.top + availableHeightCss / 2
   };
 }
 function ringParams(){
   const keyboard = keyboardMetrics();
-  const availableHeight = Math.max(1, cv.height - keyboard.reserved);
+  const availableWidth = Math.max(1, cv.width - keyboard.reservedRight);
+  const availableHeight = Math.max(1, cv.height - keyboard.reservedBottom);
   const halfHeight = availableHeight / 2;
-  const halfWidth = cv.width / 2;
+  const halfWidth = availableWidth / 2;
   const half = Math.max(1, Math.min(halfWidth, halfHeight));
   const safeHalf = Math.max(1, half - 4);
   let rMax = half - MARGIN;
@@ -1769,16 +1778,20 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
 
   const padding = keyboard.padding;
   const keyboardHeight = keyboard.height;
-  const y = cv.height - keyboardHeight - padding;
   const {cx} = canvasCenter();
   const {rMax} = ringParams();
   const diskDiameter = (rMax + 8) * 2;
-  const maxWidth = Math.min(cv.width - padding * 2, diskDiameter * 2);
-  const maxWhiteWidth = keyboardHeight / 2.2;
-  const aspectLimitedWidth = whiteKeys.length * maxWhiteWidth;
-  const width = Math.min(maxWidth, aspectLimitedWidth);
-  const x = cx - width / 2;
+  const areaWidth = (keyboard.mode === 'side')
+    ? Math.max(1, keyboard.panelWidth - padding * 2)
+    : Math.max(1, cv.width - padding * 2);
+  const width = Math.min(areaWidth, diskDiameter * 2);
   if(width <= 0 || keyboardHeight <= 0) return;
+  const x = (keyboard.mode === 'side')
+    ? (cv.width - keyboard.panelWidth) + (keyboard.panelWidth - width) / 2
+    : cx - width / 2;
+  const y = (keyboard.mode === 'side')
+    ? (cv.height - keyboardHeight) / 2
+    : cv.height - keyboardHeight - padding;
 
   const whiteWidth = width / whiteKeys.length;
   const blackWidth = whiteWidth * 0.54;

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -933,9 +933,13 @@ function keyboardMetrics(){
   if(!keyboardEnabled) return {active:false, height:0, padding:0, reserved:0};
   const padding = 16 * devicePixelRatio;
   const halfWidth = cv.width / 2;
-  const widthLimitedRadius = Math.max(1, halfWidth - MARGIN);
-  const heightLimitedRadius = Math.max(1, (cv.height - padding * 2 - MARGIN * 2) / 3);
-  const height = Math.min(widthLimitedRadius, heightLimitedRadius);
+  const radiusByWidth = Math.max(1, halfWidth - MARGIN);
+  const minDiskRadius = radiusByWidth * 0.85;
+  const maxHeightForDisk = cv.height - (minDiskRadius + MARGIN) * 2 - padding * 2;
+  const minHeight = 72 * devicePixelRatio;
+  const preferredHeight = Math.min(180 * devicePixelRatio, cv.height * 0.28);
+  const clampedMax = Math.max(0, maxHeightForDisk);
+  const height = Math.max(0, Math.min(clampedMax, Math.max(minHeight, preferredHeight)));
   return {active:true, height, padding, reserved: height + padding * 2};
 }
 function canvasCenter(){
@@ -1769,7 +1773,10 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   const {cx} = canvasCenter();
   const {rMax} = ringParams();
   const diskDiameter = (rMax + 8) * 2;
-  const width = Math.min(cv.width - padding * 2, diskDiameter * 2);
+  const maxWidth = Math.min(cv.width - padding * 2, diskDiameter * 2);
+  const maxWhiteWidth = keyboardHeight / 2.2;
+  const aspectLimitedWidth = whiteKeys.length * maxWhiteWidth;
+  const width = Math.min(maxWidth, aspectLimitedWidth);
   const x = cx - width / 2;
   if(width <= 0 || keyboardHeight <= 0) return;
 

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1784,7 +1784,9 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   const areaWidth = (keyboard.mode === 'side')
     ? Math.max(1, keyboard.panelWidth - padding * 2)
     : Math.max(1, cv.width - padding * 2);
-  const width = Math.min(areaWidth, diskDiameter * 2);
+  const maxWhiteWidth = keyboardHeight * 0.42;
+  const aspectWidthCap = whiteKeys.length * maxWhiteWidth;
+  const width = Math.min(areaWidth, diskDiameter * 2, aspectWidthCap);
   if(width <= 0 || keyboardHeight <= 0) return;
   const x = (keyboard.mode === 'side')
     ? (cv.width - keyboard.panelWidth) + (keyboard.panelWidth - width) / 2

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -935,9 +935,11 @@ function keyboardMetrics(){
   const height = Math.min(140 * devicePixelRatio, cv.height * 0.25);
   const landscape = cv.width > cv.height * 1.25;
   if(landscape){
-    const panelGap = 24 * devicePixelRatio;
-    const desiredPanelWidth = cv.width * 0.36;
-    const minDiskAreaWidth = cv.height * 0.9;
+    const panelGap = 12 * devicePixelRatio;
+    const targetDiskAreaWidth = cv.height * 1.02;
+    const panelFromTarget = cv.width - targetDiskAreaWidth - panelGap;
+    const desiredPanelWidth = Math.max(cv.width * 0.30, panelFromTarget);
+    const minDiskAreaWidth = cv.height * 0.82;
     const maxPanelWidth = Math.max(0, cv.width - minDiskAreaWidth - panelGap);
     const panelWidth = Math.min(desiredPanelWidth, maxPanelWidth);
     if(panelWidth >= 180 * devicePixelRatio){

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -932,7 +932,10 @@ function hzToMidi(f){ return 12*Math.log2(f/440)+69; }
 function keyboardMetrics(){
   if(!keyboardEnabled) return {active:false, height:0, padding:0, reserved:0};
   const padding = 16 * devicePixelRatio;
-  const height = Math.min(140 * devicePixelRatio, cv.height * 0.25);
+  const halfWidth = cv.width / 2;
+  const widthLimitedRadius = Math.max(1, halfWidth - MARGIN);
+  const heightLimitedRadius = Math.max(1, (cv.height - padding * 2 - MARGIN * 2) / 3);
+  const height = Math.min(widthLimitedRadius, heightLimitedRadius);
   return {active:true, height, padding, reserved: height + padding * 2};
 }
 function canvasCenter(){

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2101,11 +2101,13 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
       const targetPc = ((targetMidi % 12) + 12) % 12;
       candidates = keys.filter((key)=> key.pc === targetPc);
     }
-    if(role === 'lowest' && highestMidi != null){
-      candidates = candidates.filter((key)=> key.midi <= highestMidi);
+    const lowestOctaveGuardTop = startMidi + 12;
+    const highestOctaveGuardBottom = endMidi - 12;
+    if(role === 'highest'){
+      candidates = candidates.filter((key)=> key.midi >= lowestOctaveGuardTop);
     }
-    if(role === 'highest' && lowestMidi != null){
-      candidates = candidates.filter((key)=> key.midi >= lowestMidi);
+    if(role === 'lowest'){
+      candidates = candidates.filter((key)=> key.midi <= highestOctaveGuardBottom);
     }
     return candidates;
   };

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2092,24 +2092,24 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   }
   drawBlackKeyOverlay();
 
-  const highlightKeysForMidi = (targetMidi, role)=>{
+  const highlightKeysForMidi = (targetMidi, {role, minAllowedMidi = -Infinity} = {})=>{
     if(targetMidi == null) return [];
+    const targetPc = ((targetMidi % 12) + 12) % 12;
     let candidates;
+    if(role === 'lowest'){
+      candidates = keys.filter((key)=> key.pc === targetPc);
+      if(candidates.length){
+        const lowestMatchMidi = Math.min(...candidates.map((key)=> key.midi));
+        return candidates.filter((key)=> key.midi === lowestMatchMidi);
+      }
+      return [];
+    }
     if(targetMidi >= startMidi && targetMidi <= endMidi){
       candidates = keys.filter((key)=> key.midi === targetMidi);
     }else{
-      const targetPc = ((targetMidi % 12) + 12) % 12;
       candidates = keys.filter((key)=> key.pc === targetPc);
     }
-    const lowestOctaveGuardTop = startMidi + 12;
-    const highestOctaveGuardBottom = endMidi - 12;
-    if(role === 'highest'){
-      candidates = candidates.filter((key)=> key.midi >= lowestOctaveGuardTop);
-    }
-    if(role === 'lowest'){
-      candidates = candidates.filter((key)=> key.midi <= highestOctaveGuardBottom);
-    }
-    return candidates;
+    return candidates.filter((key)=> key.midi > minAllowedMidi);
   };
 
   const drawHighlight = (targetKeys, strokeStyle, shadowColor)=>{
@@ -2130,13 +2130,17 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     ctx.restore();
   };
 
+  const lowestHighlightKeys = highlightKeysForMidi(lowestMidi, {role:'lowest'});
+  const lowestHighlightedMidi = lowestHighlightKeys.length
+    ? Math.max(...lowestHighlightKeys.map((key)=> key.midi))
+    : -Infinity;
   drawHighlight(
-    highlightKeysForMidi(lowestMidi, 'lowest'),
+    lowestHighlightKeys,
     'rgba(0,200,255,0.98)',
     'rgba(100,220,255,0.85)'
   );
   drawHighlight(
-    highlightKeysForMidi(highestMidi, 'highest'),
+    highlightKeysForMidi(highestMidi, {role:'highest', minAllowedMidi: lowestHighlightedMidi}),
     'rgba(255,160,0,0.98)',
     'rgba(255,200,0,0.85)'
   );


### PR DESCRIPTION
### Motivation
- The keyboard should show a shorter white-only lower portion (the area without black keys) to match a requested 1/2 length change. 
- The keyboard should be allowed to grow wider than the disk when screen space permits, up to twice the disk diameter.

### Description
- Updated keyboard max width calculation to allow expansion to `diskDiameter * 2` while still respecting viewport padding by changing `const width = Math.min(cv.width - padding * 2, diskDiameter)` to `const width = Math.min(cv.width - padding * 2, diskDiameter * 2)` in `Tonality Visualizer/index.html`.
- Computed a reduced white-key lower area by deriving `whiteLowerHeight = Math.max(0, (keyboardHeight - blackHeight) * 0.5)` and setting `whiteHeight = blackHeight + whiteLowerHeight` so the white-only portion becomes half of its previous size.
- Applied the new white key height by replacing uses of `keyboardHeight` for white-key drawing with `whiteHeight` so rendering reflects the shorter lower region.

### Testing
- Inspected the diff with `git diff -- 'Tonality Visualizer/index.html'` and committed the change with `git add`/`git commit`, both succeeded. 
- Started a static file server with `python3 -m http.server 4173` to expose the page for visual validation, which ran successfully. 
- Attempted an automated screenshot via Playwright (`mcp__browser_tools__run_playwright_script`) but Chromium crashed with a SIGSEGV in this environment, so visual confirmation could not be captured automatically. 
- Verified repository status with `git status --short` and confirmed the modified file is `Tonality Visualizer/index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59de634f483308be009ad051cd8e9)