### PR TITLE
Remove K2 continuous disk-angle rotation behavior

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2611,9 +2611,9 @@ function draw(){
   ctx.restore();
 
   if(k2Info){
-    // K2 は 30°刻みの判定Δに加えて、円盤回転そのものにも追従させる
-    // （anchor設定に関係なく diskAngle を常に反映）
-    const k2BaseCenter = GRAV_ABS - diskAngle;
+    // K2の基準角はK1と同じアンカー基準に統一する
+    // （disk angleへの常時追従設定は廃止）
+    const k2BaseCenter = GRAV_ABS - drawRot;
     const k2Center = k2BaseCenter + (k2Info.appliedDeltaDeg * Math.PI / 180);
     ctx.save(); ctx.translate(cx,cy);
     const k2Path = halfPlanePath(k2Center, rMax+6);


### PR DESCRIPTION
### Motivation
- Remove the special-case behavior that made the K2 water region always follow `diskAngle` so that K2 uses the same anchor-based rotation as K1 (`drawRot`).

### Description
- Updated `Tonality Visualizer/index.html` to replace `const k2BaseCenter = GRAV_ABS - diskAngle;` with `const k2BaseCenter = GRAV_ABS - drawRot;` and revised the inline comment to note the always-follow-disk-angle behavior was removed.

### Testing
- No automated tests are configured in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7774168083309860aa5382550c79)