### PR TITLE
Add degree-name display to chord overlay

### DIFF
--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -982,19 +982,6 @@ function keyboardMetrics(){
   if(!keyboardEnabled) return {active:false, mode:'none', height:0, padding:0, reservedBottom:0, reservedRight:0, panelWidth:0, panelGap:0};
   const padding = 16 * devicePixelRatio;
   const height = Math.min(140 * devicePixelRatio, cv.height * 0.25);
-  const landscape = cv.width > cv.height * 1.25;
-  if(landscape){
-    const panelGap = 12 * devicePixelRatio;
-    const targetDiskAreaWidth = cv.height * 1.02;
-    const panelFromTarget = cv.width - targetDiskAreaWidth - panelGap;
-    const desiredPanelWidth = Math.max(cv.width * 0.30, panelFromTarget);
-    const minDiskAreaWidth = cv.height * 0.82;
-    const maxPanelWidth = Math.max(0, cv.width - minDiskAreaWidth - panelGap);
-    const panelWidth = Math.min(desiredPanelWidth, maxPanelWidth);
-    if(panelWidth >= 180 * devicePixelRatio){
-      return {active:true, mode:'side', height, padding, reservedBottom:0, reservedRight:panelWidth + panelGap, panelWidth, panelGap};
-    }
-  }
   return {active:true, mode:'bottom', height, padding, reservedBottom:height + padding * 2, reservedRight:0, panelWidth:0, panelGap:0};
 }
 function canvasCenter(){
@@ -2190,6 +2177,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     const rootMidi = compositionSummary.highlightRootMidi;
     const cwPcs = new Set(compositionSummary.keyboardHighlightCwPcs || compositionSummary.highlightCwPcs || []);
     const ccwPcs = new Set(compositionSummary.keyboardHighlightCcwPcs || compositionSummary.highlightCcwPcs || []);
+    const activePcs = new Set(compositionSummary.activePcs || []);
     const alpha = Math.max(0.25, Math.min(0.85, outerHighlightAlpha));
     const radiusWhite = Math.max(blackWidth * 0.34, 8 * devicePixelRatio);
     const radiusBlack = Math.max(blackWidth * 0.3, 7 * devicePixelRatio);
@@ -2205,8 +2193,9 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
 
     for(const key of keys){
       const isRoot = (rootMidi != null && key.midi === rootMidi);
-      const cw = cwPcs.has(key.pc);
-      const ccw = ccwPcs.has(key.pc);
+      const outsideK1 = K2_OUTSIDE_BITS.includes(degreeForPitchClass(key.pc, drawRot, halfCenter));
+      const cw = !isRoot && cwPcs.has(key.pc) && (!outsideK1 || activePcs.has(key.pc));
+      const ccw = !isRoot && ccwPcs.has(key.pc) && (!outsideK1 || activePcs.has(key.pc));
       if(!isRoot && !cw && !ccw) continue;
       const centerX = key.isBlack ? (key.x + key.width / 2) : movableLabelXForWhiteKey(key);
       const centerY = key.isBlack ? movableYBlack : movableYWhite;
@@ -2858,14 +2847,8 @@ function drawCompositionOverlay(summary){
   let x = cv.width - boxW - 12 * devicePixelRatio;
   let y = 12 * devicePixelRatio;
   if(keyboard.active){
-    if(keyboard.mode === 'side'){
-      x = cv.width - keyboard.panelWidth + 12 * devicePixelRatio;
-      y = 12 * devicePixelRatio;
-    }else{
-      const keyTop = cv.height - keyboard.height - keyboard.padding;
-      y = Math.max(12 * devicePixelRatio, keyTop - boxH - 10 * devicePixelRatio);
-      x = (cv.width - boxW) / 2;
-    }
+    x = cv.width - boxW - 12 * devicePixelRatio;
+    y = 12 * devicePixelRatio;
   }else{
     const {cx, cy} = canvasCenter();
     const {rMax} = ringParams();
@@ -2908,7 +2891,8 @@ function drawChordOverlay(chordSummary){
   ctx.save();
   ctx.font = `${textSize}px system-ui`;
 
-  const maxH = cv.height - 24 * devicePixelRatio;
+  const keyReserved = keyboardEnabled ? (keyboardMetrics().height + keyboardMetrics().padding * 2) : 0;
+  const maxH = cv.height - 24 * devicePixelRatio - keyReserved;
   const rowH = textSize + lineGap;
   const headerHeight = rowH * headerLines.length;
   const availableForCandidates = Math.max(rowH, maxH - (pad * 2 + headerHeight));
@@ -3125,6 +3109,9 @@ function draw(){
     ctx.fillStyle = `rgba(${r},${g},${b},${labelBgAlpha})`;
     ctx.fillRect(tx2 - wbg/2, ty2 - hbg/2, wbg, hbg);
     if(labelTextAlpha>0){
+      ctx.lineWidth = Math.max(1, 2 * devicePixelRatio);
+      ctx.strokeStyle='rgba(0,0,0,0.9)';
+      ctx.strokeText(text, tx2, ty2);
       ctx.fillStyle=`rgba(255,255,255,${labelTextAlpha})`;
       ctx.fillText(text, tx2, ty2);
     }

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -982,6 +982,19 @@ function keyboardMetrics(){
   if(!keyboardEnabled) return {active:false, mode:'none', height:0, padding:0, reservedBottom:0, reservedRight:0, panelWidth:0, panelGap:0};
   const padding = 16 * devicePixelRatio;
   const height = Math.min(140 * devicePixelRatio, cv.height * 0.25);
+  const landscape = cv.width > cv.height * 1.25;
+  if(landscape){
+    const panelGap = 12 * devicePixelRatio;
+    const targetDiskAreaWidth = cv.height * 1.02;
+    const panelFromTarget = cv.width - targetDiskAreaWidth - panelGap;
+    const desiredPanelWidth = Math.max(cv.width * 0.30, panelFromTarget);
+    const minDiskAreaWidth = cv.height * 0.82;
+    const maxPanelWidth = Math.max(0, cv.width - minDiskAreaWidth - panelGap);
+    const panelWidth = Math.min(desiredPanelWidth, maxPanelWidth);
+    if(panelWidth >= 180 * devicePixelRatio){
+      return {active:true, mode:'side', height, padding, reservedBottom:0, reservedRight:panelWidth + panelGap, panelWidth, panelGap};
+    }
+  }
   return {active:true, mode:'bottom', height, padding, reservedBottom:height + padding * 2, reservedRight:0, panelWidth:0, panelGap:0};
 }
 function canvasCenter(){
@@ -1853,7 +1866,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     ? (cv.width - keyboard.panelWidth) + (keyboard.panelWidth - width) / 2
     : cx - width / 2;
   const y = (keyboard.mode === 'side')
-    ? (cv.height - keyboardHeight) / 2
+    ? (cv.height - keyboardHeight - padding)
     : cv.height - keyboardHeight - padding;
 
   const whiteWidth = width / whiteKeys.length;
@@ -2847,8 +2860,14 @@ function drawCompositionOverlay(summary){
   let x = cv.width - boxW - 12 * devicePixelRatio;
   let y = 12 * devicePixelRatio;
   if(keyboard.active){
-    x = cv.width - boxW - 12 * devicePixelRatio;
-    y = 12 * devicePixelRatio;
+    if(keyboard.mode === 'side'){
+      const panelX = cv.width - keyboard.panelWidth;
+      x = panelX + Math.max(8 * devicePixelRatio, keyboard.panelWidth * 0.5 - boxW - 6 * devicePixelRatio);
+      y = 12 * devicePixelRatio;
+    }else{
+      x = cv.width - boxW - 12 * devicePixelRatio;
+      y = 12 * devicePixelRatio;
+    }
   }else{
     const {cx, cy} = canvasCenter();
     const {rMax} = ringParams();
@@ -2891,7 +2910,8 @@ function drawChordOverlay(chordSummary){
   ctx.save();
   ctx.font = `${textSize}px system-ui`;
 
-  const keyReserved = keyboardEnabled ? (keyboardMetrics().height + keyboardMetrics().padding * 2) : 0;
+  const km = keyboardMetrics();
+  const keyReserved = (keyboardEnabled && km.mode !== 'side') ? (km.height + km.padding * 2) : 0;
   const maxH = cv.height - 24 * devicePixelRatio - keyReserved;
   const rowH = textSize + lineGap;
   const headerHeight = rowH * headerLines.length;
@@ -2910,8 +2930,15 @@ function drawChordOverlay(chordSummary){
   const candidateRowsMax = Math.max(...columns.map((c)=>c.length), 0);
   const boxH = pad * 2 + headerHeight + candidateRowsMax * rowH;
 
-  const x = 12 * devicePixelRatio;
+  let x = 12 * devicePixelRatio;
   const y = 12 * devicePixelRatio;
+  if(keyboardEnabled){
+    const km2 = keyboardMetrics();
+    if(km2.mode === 'side'){
+      const panelX = cv.width - km2.panelWidth;
+      x = panelX + 10 * devicePixelRatio;
+    }
+  }
   const boxAlpha = Math.max(0, Math.min(1, compositionInfoAlpha));
   ctx.fillStyle = `rgba(10,14,20,${0.76 * boxAlpha})`;
   ctx.fillRect(x, y, boxW, boxH);

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2188,6 +2188,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   const drawOuterRoleHighlightsOnKeyboard = ()=>{
     if(!compositionSummary) return;
     const rootMidi = compositionSummary.highlightRootMidi;
+    const rootPc = compositionSummary.rootPc;
     const cwPcs = new Set(compositionSummary.keyboardHighlightCwPcs || compositionSummary.highlightCwPcs || []);
     const ccwPcs = new Set(compositionSummary.keyboardHighlightCcwPcs || compositionSummary.highlightCcwPcs || []);
     const activePcs = new Set(compositionSummary.activePcs || []);
@@ -2204,8 +2205,11 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
       ctx.fill();
     };
 
+    const rootCandidates = keys.filter((key)=> rootPc != null && key.pc === rootPc);
+    const rootKeyMidi = rootCandidates.length ? Math.min(...rootCandidates.map((key)=>key.midi)) : rootMidi;
+
     for(const key of keys){
-      const isRoot = (rootMidi != null && key.midi === rootMidi);
+      const isRoot = (rootPc != null) ? (key.midi === rootKeyMidi) : (rootMidi != null && key.midi === rootMidi);
       const outsideK1 = K2_OUTSIDE_BITS.includes(degreeForPitchClass(key.pc, drawRot, halfCenter));
       const cw = !isRoot && cwPcs.has(key.pc) && (!outsideK1 || activePcs.has(key.pc));
       const ccw = !isRoot && ccwPcs.has(key.pc) && (!outsideK1 || activePcs.has(key.pc));
@@ -2862,7 +2866,8 @@ function drawCompositionOverlay(summary){
   if(keyboard.active){
     if(keyboard.mode === 'side'){
       const panelX = cv.width - keyboard.panelWidth;
-      x = panelX + Math.max(8 * devicePixelRatio, keyboard.panelWidth * 0.5 - boxW - 6 * devicePixelRatio);
+      const halfW = keyboard.panelWidth * 0.5;
+      x = panelX + halfW + Math.max(8 * devicePixelRatio, (halfW - boxW) * 0.5);
       y = 12 * devicePixelRatio;
     }else{
       x = cv.width - boxW - 12 * devicePixelRatio;
@@ -2936,7 +2941,8 @@ function drawChordOverlay(chordSummary){
     const km2 = keyboardMetrics();
     if(km2.mode === 'side'){
       const panelX = cv.width - km2.panelWidth;
-      x = panelX + 10 * devicePixelRatio;
+      const halfW = km2.panelWidth * 0.5;
+      x = panelX + Math.max(8 * devicePixelRatio, (halfW - boxW) * 0.5);
     }
   }
   const boxAlpha = Math.max(0, Math.min(1, compositionInfoAlpha));

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2188,8 +2188,8 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
   const drawOuterRoleHighlightsOnKeyboard = ()=>{
     if(!compositionSummary) return;
     const rootMidi = compositionSummary.highlightRootMidi;
-    const cwPcs = new Set(compositionSummary.highlightCwPcs || []);
-    const ccwPcs = new Set(compositionSummary.highlightCcwPcs || []);
+    const cwPcs = new Set(compositionSummary.keyboardHighlightCwPcs || compositionSummary.highlightCwPcs || []);
+    const ccwPcs = new Set(compositionSummary.keyboardHighlightCcwPcs || compositionSummary.highlightCcwPcs || []);
     const alpha = Math.max(0.25, Math.min(0.85, outerHighlightAlpha));
     const radiusWhite = Math.max(blackWidth * 0.34, 8 * devicePixelRatio);
     const radiusBlack = Math.max(blackWidth * 0.3, 7 * devicePixelRatio);
@@ -2213,7 +2213,7 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
       const radius = key.isBlack ? radiusBlack : radiusWhite;
       if(cw) drawCircle(centerX, centerY, radius, `rgba(90,255,120,${alpha})`);
       if(ccw) drawCircle(centerX, centerY, radius, `rgba(255,90,90,${alpha})`);
-      if(isRoot) drawCircle(centerX, centerY, radius * 0.72, `rgba(255,255,255,${Math.max(alpha, 0.5)})`);
+      if(isRoot) drawCircle(centerX, centerY, radius * 0.96, `rgba(255,255,255,${Math.max(alpha, 0.62)})`);
     }
   };
 
@@ -2745,17 +2745,20 @@ function noteCompositionSummary(activeNotes, drawRot, halfCenter){
   ].filter((midi)=>midi!=null).map((midi)=>((midi%12)+12)%12);
   const highlightCwPcs = [];
   const highlightCcwPcs = [];
+  const keyboardHighlightCwPcs = [];
+  const keyboardHighlightCcwPcs = [];
   if(Number.isFinite(rootAngleInK1)){
     for(let pc=0; pc<12; pc++){
       const degree = degreeForPitchClass(pc, drawRot, halfCenter);
       const inK1 = !K2_OUTSIDE_BITS.includes(degree);
-      if(!inK1) continue;
       const angleInK = kAngleInKForPitchClass(pc, drawRot, halfCenter);
       if(Number.isFinite(aroundRoot?.cw?.delta) && normalizeAngleDeg(rootAngleInK1 - angleInK) <= aroundRoot.cw.delta + 1e-6){
-        highlightCwPcs.push(pc);
+        keyboardHighlightCwPcs.push(pc);
+        if(inK1) highlightCwPcs.push(pc);
       }
       if(Number.isFinite(aroundRoot?.ccw?.delta) && normalizeAngleDeg(angleInK - rootAngleInK1) <= aroundRoot.ccw.delta + 1e-6){
-        highlightCcwPcs.push(pc);
+        keyboardHighlightCcwPcs.push(pc);
+        if(inK1) highlightCcwPcs.push(pc);
       }
     }
   }
@@ -2789,7 +2792,9 @@ function noteCompositionSummary(activeNotes, drawRot, halfCenter){
     highlightCwMidis: cwHighlightDegrees.map((deg)=>degreeToMidi.get(deg)).filter((midi)=>midi!=null),
     highlightCcwMidis: ccwHighlightDegrees.map((deg)=>degreeToMidi.get(deg)).filter((midi)=>midi!=null),
     highlightCwPcs,
-    highlightCcwPcs
+    highlightCcwPcs,
+    keyboardHighlightCwPcs: uniqueSorted(keyboardHighlightCwPcs),
+    keyboardHighlightCcwPcs: uniqueSorted(keyboardHighlightCcwPcs)
   };
 }
 function drawOuterAngleHighlights(summary, drawRot, halfCenter, rMax){

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -1832,7 +1832,7 @@ function movableDoStepForMidi(midi, drawRot, halfCenter){
   return step;
 }
 
-function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCenter, lowestMidi=null, highestMidi=null){
+function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCenter, lowestMidi=null, highestMidi=null, compositionSummary=null){
   if(!keyboardEnabled) return;
   const {minMidi, maxMidi} = midiRangeFromDisplay(displayMinFreq, displayMaxFreq);
   if(minMidi > maxMidi) return;
@@ -2184,6 +2184,22 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     }
     ctx.restore();
   };
+
+  const drawOuterRoleHighlightsOnKeyboard = ()=>{
+    if(!compositionSummary) return;
+    const rootMidi = compositionSummary.highlightRootMidi;
+    const cwPcs = new Set(compositionSummary.highlightCwPcs || []);
+    const ccwPcs = new Set(compositionSummary.highlightCcwPcs || []);
+    const isRoot = (key)=> rootMidi != null && key.midi === rootMidi;
+    const cwKeys = keys.filter((key)=>cwPcs.has(key.pc) && !isRoot(key));
+    const ccwKeys = keys.filter((key)=>ccwPcs.has(key.pc) && !isRoot(key));
+    const rootKeys = rootMidi == null ? [] : keys.filter((key)=>key.midi === rootMidi);
+    drawHighlight(cwKeys, `rgba(90,255,120,${Math.max(0.4, outerHighlightAlpha)})`, `rgba(90,255,120,0.65)`);
+    drawHighlight(ccwKeys, `rgba(255,90,90,${Math.max(0.4, outerHighlightAlpha)})`, `rgba(255,90,90,0.65)`);
+    drawHighlight(rootKeys, `rgba(255,255,255,${Math.max(0.55, outerHighlightAlpha)})`, `rgba(255,255,255,0.75)`);
+  };
+
+  drawOuterRoleHighlightsOnKeyboard();
 
   const lowestHighlightKeys = highlightKeysForMidi(lowestMidi, {role:'lowest'});
   const lowestHighlightedMidi = lowestHighlightKeys.length
@@ -3123,7 +3139,8 @@ function draw(){
     drawRot,
     halfCenter,
     lowestMidi,
-    highestMidi
+    highestMidi,
+    compositionSummary
   );
 
   requestAnimationFrame(draw);

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2486,7 +2486,15 @@ function buildChordDisplaySummary(compositionSummary){
   const highlighted = new Set([...(compositionSummary.highlightCwPcs || []), ...(compositionSummary.highlightCcwPcs || [])]);
   const optionalPcs = uniqueSorted(Array.from(highlighted).filter((pc)=> pc!==rootPc && !formalPcs.includes(pc)));
 
+  const rootLabel = PITCH_CLASS_LABELS[rootPc] || '';
+  const rootRoman = compositionSummary.rootRoman || 'I';
+  const degreeCodeFromChordName = (name)=>{
+    if(!rootLabel || typeof name !== 'string') return name;
+    return name.startsWith(rootLabel) ? `${rootRoman}${name.slice(rootLabel.length)}` : `${rootRoman}(${name})`;
+  };
+
   const formalCode = generateChordName(rootPc, formalPcs);
+  const formalDegreeCode = degreeCodeFromChordName(formalCode);
   const candidates = [];
   for(const mask of subsetMasks(optionalPcs.length)){
     const picked=[];
@@ -2494,7 +2502,7 @@ function buildChordDisplaySummary(compositionSummary){
     const name = generateChordName(rootPc, [...formalPcs, ...picked]);
     if(name===formalCode) continue;
     const intervals = picked.map((pc)=>((pc-rootPc)%12+12)%12);
-    candidates.push({name, picked, score:scoreCandidateChord(name, intervals)});
+    candidates.push({name, degreeName: degreeCodeFromChordName(name), picked, score:scoreCandidateChord(name, intervals)});
   }
   const dedup = new Map();
   for(const c of candidates){
@@ -2502,7 +2510,7 @@ function buildChordDisplaySummary(compositionSummary){
     if(!prev || c.score>prev.score || (c.score===prev.score && c.picked.length>prev.picked.length)) dedup.set(c.name,c);
   }
   const out = Array.from(dedup.values()).sort((a,b)=> b.score-a.score || a.name.length-b.name.length);
-  return {formalCode, candidates: out, rootPc, optionalPcs};
+  return {formalCode, formalDegreeCode, candidates: out, rootPc, optionalPcs};
 }
 
 function degreeForPitchClass(pc, drawRot, halfCenter){
@@ -2728,6 +2736,7 @@ function noteCompositionSummary(activeNotes, drawRot, halfCenter){
   return {
     absoluteLine: absolute.join(' '),
     relativeLine: [rootRoman, ...relative.slice(1)].join(' '),
+    rootRoman,
     k2,
     k2Line1: k2RangeText,
     k2Line2: `Outside tones: ${outsideText}`,
@@ -2850,10 +2859,11 @@ function drawChordOverlay(chordSummary){
   const textSize = Math.max(11 * devicePixelRatio, labelFontPx * devicePixelRatio * 0.9);
   const headerLines = [
     `Chord: ${chordSummary.formalCode}`,
+    `Degree: ${chordSummary.formalDegreeCode || '–'}`,
     `Candidates:`
   ];
   const candidateLines = chordSummary.candidates.length
-    ? chordSummary.candidates.map((c)=>c.name)
+    ? chordSummary.candidates.map((c)=>`${c.name} | ${c.degreeName || '–'}`)
     : ['–'];
 
   ctx.save();

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2190,13 +2190,31 @@ function drawKeyboard(displayMinFreq, displayMaxFreq, baseMidi, drawRot, halfCen
     const rootMidi = compositionSummary.highlightRootMidi;
     const cwPcs = new Set(compositionSummary.highlightCwPcs || []);
     const ccwPcs = new Set(compositionSummary.highlightCcwPcs || []);
-    const isRoot = (key)=> rootMidi != null && key.midi === rootMidi;
-    const cwKeys = keys.filter((key)=>cwPcs.has(key.pc) && !isRoot(key));
-    const ccwKeys = keys.filter((key)=>ccwPcs.has(key.pc) && !isRoot(key));
-    const rootKeys = rootMidi == null ? [] : keys.filter((key)=>key.midi === rootMidi);
-    drawHighlight(cwKeys, `rgba(90,255,120,${Math.max(0.4, outerHighlightAlpha)})`, `rgba(90,255,120,0.65)`);
-    drawHighlight(ccwKeys, `rgba(255,90,90,${Math.max(0.4, outerHighlightAlpha)})`, `rgba(255,90,90,0.65)`);
-    drawHighlight(rootKeys, `rgba(255,255,255,${Math.max(0.55, outerHighlightAlpha)})`, `rgba(255,255,255,0.75)`);
+    const alpha = Math.max(0.25, Math.min(0.85, outerHighlightAlpha));
+    const radiusWhite = Math.max(blackWidth * 0.34, 8 * devicePixelRatio);
+    const radiusBlack = Math.max(blackWidth * 0.3, 7 * devicePixelRatio);
+    const movableYWhite = y + keyboardHeight - Math.max(10 * devicePixelRatio, blackWidth * 0.62);
+    const movableYBlack = y + blackHeight - Math.max(10 * devicePixelRatio, blackWidth * 0.52);
+
+    const drawCircle = (cx, cy, radius, color)=>{
+      ctx.beginPath();
+      ctx.fillStyle = color;
+      ctx.arc(cx, cy, radius, 0, 2 * Math.PI);
+      ctx.fill();
+    };
+
+    for(const key of keys){
+      const isRoot = (rootMidi != null && key.midi === rootMidi);
+      const cw = cwPcs.has(key.pc);
+      const ccw = ccwPcs.has(key.pc);
+      if(!isRoot && !cw && !ccw) continue;
+      const centerX = key.isBlack ? (key.x + key.width / 2) : movableLabelXForWhiteKey(key);
+      const centerY = key.isBlack ? movableYBlack : movableYWhite;
+      const radius = key.isBlack ? radiusBlack : radiusWhite;
+      if(cw) drawCircle(centerX, centerY, radius, `rgba(90,255,120,${alpha})`);
+      if(ccw) drawCircle(centerX, centerY, radius, `rgba(255,90,90,${alpha})`);
+      if(isRoot) drawCircle(centerX, centerY, radius * 0.72, `rgba(255,255,255,${Math.max(alpha, 0.5)})`);
+    }
   };
 
   drawOuterRoleHighlightsOnKeyboard();

--- a/Tonality Visualizer/index.html
+++ b/Tonality Visualizer/index.html
@@ -2941,8 +2941,7 @@ function drawChordOverlay(chordSummary){
     const km2 = keyboardMetrics();
     if(km2.mode === 'side'){
       const panelX = cv.width - km2.panelWidth;
-      const halfW = km2.panelWidth * 0.5;
-      x = panelX + Math.max(8 * devicePixelRatio, (halfW - boxW) * 0.5);
+      x = panelX + 8 * devicePixelRatio;
     }
   }
   const boxAlpha = Math.max(0, Math.min(1, compositionInfoAlpha));


### PR DESCRIPTION
### Motivation
- Provide a degree-based (Roman numeral / movable-do) label alongside chord names so the overlay shows both chord notation and its degree representation for easier harmonic reading.

### Description
- Compute a degree-style label generator (`degreeCodeFromChordName`) using the composition root and attach `formalDegreeCode` to the formal chord returned by `buildChordDisplaySummary`.
- Include `degreeName` on each candidate entry when building candidate chords and dedupe/sort as before.
- Expose `rootRoman` in the composition summary so degree labels can be derived consistently from the current root context.
- Update `drawChordOverlay` to render a new `Degree:` line and show candidates as `Chord | Degree` in the overlay UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f227fd548330adb0b9ca8eb68403)